### PR TITLE
Implement D38/D39: GameStateView GDScript query exposure and AtomKind constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0-alpha.5] - 2026-03-23
+
+### Added
+- Generated `ArchetypeNode` now stores `GameStateView` and exposes seven GDScript-callable state query methods: `GetAccumulator`, `HasCondition`, `GetComputedProperty`, `GetZone`, `GetOwner`, `GetKind`, `GetAtoms` (D38)
+- `archetype_interop.gd` forwards all seven query methods as snake_case GDScript functions
+- New generated artifact `archetype_atom_kinds.gd` exposes `ArchetypeAtomKinds` integer constants (`CARD`, `ZONE`, `PLAYER`, `SESSION`) for use with `get_atoms` and `get_kind` (D39)
+
 ## [0.3.0-alpha.4] - 2026-03-22
 
 ### Fixed

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-> Last updated: 2026-03-21 (D33 re-review: PASS — both blockers resolved. DeriveSignalSet now scans StaticEffectDef.StateContributionBlock and Trigger.FiredBlock; two new tests cover both paths. 179/179 C# tests passing.)
+> Last updated: 2026-03-23 (D38–D39: GameStateView query exposure and AtomKind GDScript constants. 229/229 C# tests passing.)
 > Branch: `impl/text-renderer`
 > All source in `src/` (4 assemblies) + `tests/Archetype.Tests/`.
 
@@ -11,7 +11,7 @@
 | Assembly | Role | Status |
 |---|---|---|
 | `Archetype.Core` | Immutable data types, interfaces, `BuiltInKeywords` registry | ✅ Complete (Tier 1 subset) |
-| `Archetype.Build` | `Kw` factory shorthands, `GameDefinitionBuilder`, `CardSet` serialization, `BuildRunner`, `GodotEmitter` (D32, D33) | ✅ Complete — D33 PASS |
+| `Archetype.Build` | `Kw` factory shorthands, `GameDefinitionBuilder`, `CardSet` serialization, `BuildRunner`, `GodotEmitter` (D32, D33, D38, D39) | ✅ Complete — D38/D39 implemented |
 | `Archetype.Engine` | Runtime executor, `GameState`, `EventLog`, `LifetimeChecker`, `TriggerResolver`, `ActionResolver`, `GameSession`, `GameSessionBuilder` | ✅ Tier 1–4 complete |
 | `Archetype.Text` | Card text renderer | ✅ Complete (Tier 4) |
 | ~~`Archetype.Tooling.Server`~~ | Removed (superseded by `Archetype.Build` code-first authoring model — D32) | ❌ Deleted |
@@ -73,6 +73,7 @@
 - `GameStateView` (public read-only view), `IGameStateReadable`
 - **D30**: `GameStateView.LastActionEvents: IReadOnlyList<GameEvent>` — events from most recently completed `ResolveAction` (including all recursive descendants); `SetLastActionEvents` called by engine after each action
 - **D30**: `EventLog.LastActionEvents` — captured in `CloseAction()` before accumulator is cleared; exposes recursive `SelfAndDescendants()` flat list
+- **D38**: `GameStateView` has `GetAccumulator`, `HasCondition`, `GetComputedProperty`, `GetZone`, `GetOwner`, `GetKind`, `GetAtoms` — generated `ArchetypeNode` stores `_stateView`, assigns before emitting `action_requested`/`prompt_requested`, exposes all seven query methods; `archetype_interop.gd` forwards all seven
 
 ---
 
@@ -500,9 +501,9 @@ All mutation handlers call `MutationHelpers.RevalidateAndBuildResponse` → retu
 | `tooling/src/renderer/panels/GraphPanel.test.tsx` | 7 | ✅ All passing (new — Group 6 graph view) |
 | `tooling/src/renderer/panels/SetOverviewPanel.test.tsx` | 7 | ✅ All passing (new — Group 6 set overview) |
 
-| `Builder/BuildRunnerTests.cs` | 26 | ✅ All passing (13 new — D33: ArchetypeNode.cs, archetype_signals.gd, archetype_interop.gd) |
+| `Builder/BuildRunnerTests.cs` | 33 | ✅ All passing (4 new — D38/D39: state query methods, AtomKind constants, interop forwarding) |
 
-**Total: 177 C# tests passing + 105 TypeScript/React tests passing (note: TypeScript tests are for the deleted Electron tooling; C# count is authoritative).**
+**Total: 229 C# tests passing (TypeScript tooling tests no longer maintained — C# count is authoritative).**
 
 ### Layer 1 (unit, isolated state)
 - `MoveCard_UpdatesCardZoneId_ToDestination`

--- a/src/Archetype.Build/BuildRunner.cs
+++ b/src/Archetype.Build/BuildRunner.cs
@@ -75,10 +75,12 @@ public static class BuildRunner
         var defJson = JsonSerializer.Serialize(definition, JsonOptions);
         File.WriteAllText(Path.Combine(archetypeDir, "game_definition.json"), defJson);
 
-        // Emit Godot interop files (D32, D33).
+        // Emit Godot interop files (D32, D33, D38, D39).
         GodotEmitter.EmitKeywordConstants(fullDefinition, archetypeDir);
         GodotEmitter.EmitSignals(fullDefinition, archetypeDir, noSignalKeywords);
         GodotEmitter.EmitArchetypeNode(fullDefinition, archetypeDir, noSignalKeywords);
         GodotEmitter.EmitInteropScripts(fullDefinition, archetypeDir, noSignalKeywords);
+        // D39: AtomKind integer constants for GDScript; does not depend on GameDefinition.
+        GodotEmitter.EmitAtomKindConstants(archetypeDir);
     }
 }

--- a/src/Archetype.Build/GodotEmitter.cs
+++ b/src/Archetype.Build/GodotEmitter.cs
@@ -4,7 +4,7 @@ using Archetype.Core;
 namespace Archetype.Build;
 
 /// <summary>
-/// Generates GDScript interop files from a <see cref="GameDefinition"/> (D32, D33).
+/// Generates GDScript interop files from a <see cref="GameDefinition"/> (D32, D33, D38, D39).
 /// <para>
 /// Files produced:
 /// <list type="bullet">
@@ -12,7 +12,8 @@ namespace Archetype.Build;
 ///   <item><c>game_events.gd</c> — GDScript signal declarations derived from keyword event log contributions.</item>
 ///   <item><c>ArchetypeNode.cs</c> — generated C# partial class bridging <c>GameSession</c> to GDScript (D33).</item>
 ///   <item><c>archetype_signals.gd</c> — per-game signal name constants in SCREAMING_SNAKE_CASE (D33).</item>
-///   <item><c>archetype_interop.gd</c> — static autoload wrapper over <c>ArchetypeNode</c> (D33).</item>
+///   <item><c>archetype_interop.gd</c> — static autoload wrapper over <c>ArchetypeNode</c> with state query forwarding methods (D33, D38).</item>
+///   <item><c>archetype_atom_kinds.gd</c> — integer constants for <see cref="AtomKind"/> values (D39).</item>
 /// </list>
 /// </para>
 /// </summary>
@@ -174,6 +175,9 @@ public static class GodotEmitter
         sb.AppendLine("    // --- Session state ---");
         sb.AppendLine("    private Task? _runTask;");
         sb.AppendLine("    private CancellationTokenSource? _cts;");
+        // _stateView is set by InnerStrategy before each action/prompt window (D38).
+        // Query methods return safe defaults when it is null (before game start or after game over).
+        sb.AppendLine("    private GameStateView? _stateView;");
         sb.AppendLine();
 
         // One TCS pair per player for action + prompt suspension.
@@ -357,6 +361,39 @@ public static class GodotEmitter
         sb.AppendLine("    }");
         sb.AppendLine();
 
+        // --- State query methods (D38) ---
+        // These forward to _stateView and return safe defaults when null (before game start or after game over).
+        sb.AppendLine("    // --- GDScript-callable state query methods (D38) ---");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns the named accumulator value for the given atom, or 0.0 if no state is available.</summary>");
+        sb.AppendLine("    public double GetAccumulator(long atomId, string name) => _stateView?.GetAccumulator(new AtomId(atomId), name) ?? 0.0;");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns whether the named condition is set on the given atom, or false if no state is available.</summary>");
+        sb.AppendLine("    public bool HasCondition(long atomId, string name) => _stateView?.HasCondition(new AtomId(atomId), name) ?? false;");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns the named computed property for the given atom, or 0.0 if no state is available.</summary>");
+        sb.AppendLine("    public double GetComputedProperty(long atomId, string name) => _stateView?.GetComputedProperty(new AtomId(atomId), name) ?? 0.0;");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns the zone atom ID for the given card atom, or 0L if no state is available.</summary>");
+        sb.AppendLine("    public long GetZone(long atomId) => _stateView != null ? (long)_stateView.GetZone(new AtomId(atomId)) : 0L;");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns the owner atom ID for the given atom, or 0L if no state is available.</summary>");
+        sb.AppendLine("    public long GetOwner(long atomId) => _stateView != null ? (long)_stateView.GetOwner(new AtomId(atomId)) : 0L;");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns the AtomKind ordinal for the given atom, or -1 if no state is available.</summary>");
+        sb.AppendLine("    public int GetKind(long atomId) => _stateView != null ? (int)_stateView.GetKind(new AtomId(atomId)) : -1;");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Returns all atom IDs of the given AtomKind as an array of longs.</summary>");
+        sb.AppendLine("    public Godot.Collections.Array GetAtoms(int kind)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        var result = new Godot.Collections.Array();");
+        sb.AppendLine("        if (_stateView == null) return result;");
+        sb.AppendLine("        foreach (var id in _stateView.GetAtoms((AtomKind)kind))");
+        sb.AppendLine("            result.Add((long)id);");
+        sb.AppendLine("        return result;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+
         // --- InnerStrategy nested class ---
         sb.AppendLine("    // --- InnerStrategy — per-player IPlayerStrategy implementation ---");
         sb.AppendLine();
@@ -387,6 +424,8 @@ public static class GodotEmitter
         sb.AppendLine("            var tcs = new TaskCompletionSource<PlayerAction?>(");
         sb.AppendLine("                TaskCreationOptions.RunContinuationsAsynchronously);");
         sb.AppendLine("            _node._pendingActions[_playerName] = tcs;");
+        // Store state before emitting so query methods are callable during the action window (D38).
+        sb.AppendLine("            _node._stateView = state;");
         sb.AppendLine("            _node.EmitSignal(SignalName.ActionRequested, _playerName, availableDict);");
         sb.AppendLine();
         sb.AppendLine("            using var reg = ct.Register(() => tcs.TrySetCanceled());");
@@ -403,6 +442,8 @@ public static class GodotEmitter
         sb.AppendLine("            var tcs = new TaskCompletionSource<PromptResponse>(");
         sb.AppendLine("                TaskCreationOptions.RunContinuationsAsynchronously);");
         sb.AppendLine("            _node._pendingPrompts[_playerName] = tcs;");
+        // Store state before emitting so query methods are callable during the prompt window (D38).
+        sb.AppendLine("            _node._stateView = state;");
         sb.AppendLine("            _node.EmitSignal(SignalName.PromptRequested, _playerName, promptType, contextDict);");
         sb.AppendLine();
         sb.AppendLine("            using var reg = ct.Register(() => tcs.TrySetCanceled());");
@@ -639,8 +680,70 @@ public static class GodotEmitter
         sb.AppendLine("## [param response] is a dictionary of chosen values keyed by prompt field name.");
         sb.AppendLine("func submit_prompt_response(player_name: String, response: Dictionary) -> void:");
         sb.AppendLine("    _node.SubmitPromptResponse(player_name, response)");
+        sb.AppendLine();
+        // State query forwarding methods (D38).
+        // These are callable outside an action window but return safe defaults — callers should
+        // not rely on meaningful values outside the action_requested / prompt_requested window.
+        sb.AppendLine("## Returns the named accumulator value for [param atom_id].");
+        sb.AppendLine("## Returns 0.0 before the game starts or after it ends.");
+        sb.AppendLine("func get_accumulator(atom_id: int, name: String) -> float:     return _node.GetAccumulator(atom_id, name)");
+        sb.AppendLine();
+        sb.AppendLine("## Returns true if the named condition is set on [param atom_id].");
+        sb.AppendLine("## Returns false before the game starts or after it ends.");
+        sb.AppendLine("func has_condition(atom_id: int, name: String) -> bool:        return _node.HasCondition(atom_id, name)");
+        sb.AppendLine();
+        sb.AppendLine("## Returns the named computed property for [param atom_id].");
+        sb.AppendLine("## Returns 0.0 before the game starts or after it ends.");
+        sb.AppendLine("func get_computed_property(atom_id: int, name: String) -> float: return _node.GetComputedProperty(atom_id, name)");
+        sb.AppendLine();
+        sb.AppendLine("## Returns the zone atom ID for the given card atom.");
+        sb.AppendLine("## Returns 0 before the game starts or after it ends.");
+        sb.AppendLine("func get_zone(atom_id: int) -> int:                            return _node.GetZone(atom_id)");
+        sb.AppendLine();
+        sb.AppendLine("## Returns the owner atom ID for the given atom.");
+        sb.AppendLine("## Returns 0 before the game starts or after it ends.");
+        sb.AppendLine("func get_owner(atom_id: int) -> int:                           return _node.GetOwner(atom_id)");
+        sb.AppendLine();
+        sb.AppendLine("## Returns the [ArchetypeAtomKinds] integer constant for the given atom.");
+        sb.AppendLine("## Returns -1 before the game starts or after it ends.");
+        sb.AppendLine("func get_kind(atom_id: int) -> int:                            return _node.GetKind(atom_id)");
+        sb.AppendLine();
+        sb.AppendLine("## Returns all atom IDs of the given [param kind] as an Array of ints.");
+        sb.AppendLine("## Returns an empty Array before the game starts or after it ends.");
+        sb.AppendLine("func get_atoms(kind: int) -> Array:                            return _node.GetAtoms(kind)");
 
         File.WriteAllText(Path.Combine(outputDir, "archetype_interop.gd"), sb.ToString());
+    }
+
+    // -----------------------------------------------------------------------
+    //  AtomKind constants file (D39)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Emits <c>archetype_atom_kinds.gd</c> to <paramref name="outputDir"/> (D39).
+    /// <para>
+    /// Contains integer constants for each <see cref="AtomKind"/> value so GDScript
+    /// can pass kinds to <c>ArchetypeInterop.get_atoms</c> and read the result of
+    /// <c>ArchetypeInterop.get_kind</c> without hard-coding magic numbers.
+    /// The values are the underlying <c>int</c> ordinals of <see cref="AtomKind"/>
+    /// in declaration order: Card=0, Zone=1, Player=2, Session=3.
+    /// </para>
+    /// </summary>
+    public static void EmitAtomKindConstants(string outputDir)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# archetype_atom_kinds.gd — generated by Archetype.Build; do not edit");
+        sb.AppendLine("## Integer constants for AtomKind values.");
+        sb.AppendLine("## Use with [method ArchetypeInterop.get_atoms] and [method ArchetypeInterop.get_kind].");
+        sb.AppendLine("class_name ArchetypeAtomKinds");
+        sb.AppendLine();
+        // Values must match AtomKind enum declaration order in Archetype.Core (D39 cross-language contract).
+        sb.AppendLine($"const CARD    = {(int)AtomKind.Card}");
+        sb.AppendLine($"const ZONE    = {(int)AtomKind.Zone}");
+        sb.AppendLine($"const PLAYER  = {(int)AtomKind.Player}");
+        sb.AppendLine($"const SESSION = {(int)AtomKind.Session}");
+
+        File.WriteAllText(Path.Combine(outputDir, "archetype_atom_kinds.gd"), sb.ToString());
     }
 
     private static void CollectFromBlock(EffectBlockDef block, HashSet<string> collected)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,6 @@
     <PackageProjectUrl>https://github.com/bjornarprytz/Archetype</PackageProjectUrl>
     <PackageTags>archetype;card-game;game-engine;godot</PackageTags>
     <IsPackable>true</IsPackable>
-    <Version>0.3.0-alpha.4</Version>
+    <Version>0.3.0-alpha.5</Version>
   </PropertyGroup>
 </Project>

--- a/tests/Archetype.Tests/Builder/BuildRunnerTests.cs
+++ b/tests/Archetype.Tests/Builder/BuildRunnerTests.cs
@@ -451,4 +451,68 @@ public class BuildRunnerTests : IDisposable
 
         Assert.Equal(noSignals, withSignals);
     }
+
+    // -----------------------------------------------------------------------
+    //  archetype_atom_kinds.gd — D39
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Run_ArchetypeAtomKindsFile_IsEmitted()
+    {
+        BuildRunner.Run(BaseDefinition(), [], _outputDir);
+        Assert.True(File.Exists(GdFile("archetype_atom_kinds.gd")));
+    }
+
+    [Fact]
+    public void Run_ArchetypeAtomKindsFile_ContainsAllKinds()
+    {
+        BuildRunner.Run(BaseDefinition(), [], _outputDir);
+        var content = File.ReadAllText(GdFile("archetype_atom_kinds.gd"));
+
+        Assert.Contains("const CARD    = 0", content);
+        Assert.Contains("const ZONE    = 1", content);
+        Assert.Contains("const PLAYER  = 2", content);
+        Assert.Contains("const SESSION = 3", content);
+        Assert.Contains("class_name ArchetypeAtomKinds", content);
+    }
+
+    // -----------------------------------------------------------------------
+    //  ArchetypeNode.cs — D38 state query methods
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Run_ArchetypeNodeFile_ContainsStateQueryMethods()
+    {
+        BuildRunner.Run(BaseDefinition(), [], _outputDir);
+        var content = File.ReadAllText(CsFile("ArchetypeNode.cs"));
+
+        Assert.Contains("GetAccumulator", content);
+        Assert.Contains("HasCondition", content);
+        Assert.Contains("GetComputedProperty", content);
+        Assert.Contains("GetZone", content);
+        Assert.Contains("GetOwner", content);
+        Assert.Contains("GetKind", content);
+        Assert.Contains("GetAtoms", content);
+        // _stateView field must be present
+        Assert.Contains("_stateView", content);
+    }
+
+    // -----------------------------------------------------------------------
+    //  archetype_interop.gd — D38 forwarding methods
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Run_ArchetypeInteropFile_ContainsStateQueryForwardingMethods()
+    {
+        BuildRunner.Run(BaseDefinition(), [], _outputDir);
+        var content = File.ReadAllText(GdFile("archetype_interop.gd"));
+
+        Assert.Contains("func get_accumulator(", content);
+        Assert.Contains("func has_condition(", content);
+        Assert.Contains("func get_computed_property(", content);
+        Assert.Contains("func get_zone(", content);
+        Assert.Contains("func get_owner(", content);
+        Assert.Contains("func get_kind(", content);
+        Assert.Contains("func get_atoms(", content);
+    }
 }


### PR DESCRIPTION
## Summary

- **D38**: Generated `ArchetypeNode` now stores the current `GameStateView` in a `_stateView` field and exposes seven GDScript-callable query methods (`GetAccumulator`, `HasCondition`, `GetComputedProperty`, `GetZone`, `GetOwner`, `GetKind`, `GetAtoms`). `InnerStrategy` assigns `_stateView = state` immediately before emitting `action_requested` and `prompt_requested`, so the field is non-null for the entire decision window. `archetype_interop.gd` gains matching forwarding methods.
- **D39**: `GodotEmitter.EmitAtomKindConstants(outputDir)` generates `archetype_atom_kinds.gd` with `class_name ArchetypeAtomKinds` and constants `CARD=0`, `ZONE=1`, `PLAYER=2`, `SESSION=3`. `BuildRunner.Run` calls it as part of the standard artifact emission step.

## Architecture decisions applied

- D38: `_stateView` assigned before signal emission; safe defaults (0, false, empty array, -1) returned when null — no synchronization required, all writes/reads on Godot main thread (D33 threading invariants).
- D39: Constant values derived at generation time via `(int)AtomKind.Card` etc., so any future reordering of the C# enum is automatically reflected on rebuild.

## Test coverage

Four new tests in `tests/Archetype.Tests/Builder/BuildRunnerTests.cs`:

- `Run_ArchetypeAtomKindsFile_IsEmitted` — verifies `archetype_atom_kinds.gd` exists
- `Run_ArchetypeAtomKindsFile_ContainsAllKinds` — verifies CARD/ZONE/PLAYER/SESSION constants and `class_name ArchetypeAtomKinds`
- `Run_ArchetypeNodeFile_ContainsStateQueryMethods` — verifies all seven query methods and `_stateView` field in generated `ArchetypeNode.cs`
- `Run_ArchetypeInteropFile_ContainsStateQueryForwardingMethods` — verifies all seven `func get_*` forwarding methods in `archetype_interop.gd`

All 229 C# tests pass.

## Open questions

None. D38 and D39 are fully specified and the implementation matches the spec exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)