### PR TITLE
feat: AtomGroup — build-time cross-cutting transformations (0.6.3)

### DIFF
--- a/.claude/skills/archetype-game-structure/SKILL.md
+++ b/.claude/skills/archetype-game-structure/SKILL.md
@@ -247,6 +247,60 @@ var host = new HostManifestBuilder()
 
 ---
 
+## Atom Groups — Build-Time Cross-Cutting Transformations
+
+`AtomGroup<TDef>` selects atom definitions by predicate and applies a transformation during `Build()`, before the `GameDefinition` is finalised. Groups are purely build-time — the serialised output reflects already-applied results.
+
+Groups are applied in ascending **priority** order (lower number runs first). Registration order does not affect application order.
+
+```csharp
+// Apply a default cost to any card that has none declared.
+builder.RegisterCardGroup(
+    name:      "default-cost",
+    matcher:   card => card.Cost is null or { Count: 0 },
+    transform: card => card with { Cost = [payManaCost] },
+    priority:  0);
+
+// Tag all spell-type cards with an extra static property.
+builder.RegisterCardGroup(
+    name:      "spell-tag",
+    matcher:   card => card.StaticProperties.TryGetValue("type", out var t) && t is "spell",
+    transform: card => card with
+    {
+        StaticProperties = new Dictionary<string, object>(card.StaticProperties) { ["tagged"] = true }
+    },
+    priority:  1);
+
+// Add a default static property to every zone that lacks "hidden".
+builder.RegisterZoneGroup(
+    name:      "visible-default",
+    matcher:   zone => !zone.StaticProperties.ContainsKey("hidden"),
+    transform: zone => zone with
+    {
+        StaticProperties = new Dictionary<string, object>(zone.StaticProperties) { ["visible"] = true }
+    });
+
+// Apply a bonus static property to a specific player role.
+builder.RegisterPlayerGroup(
+    name:      "hero-bonus",
+    matcher:   p => p.StaticProperties.TryGetValue("role", out var r) && r is "hero",
+    transform: p => p with
+    {
+        StaticProperties = new Dictionary<string, object>(p.StaticProperties) { ["bonus"] = true }
+    });
+```
+
+**"Don't override local" pattern:** put the guard in the matcher, not the framework.
+
+```csharp
+// Only set cost if the card author didn't explicitly declare one.
+matcher: card => card.Cost is null or { Count: 0 }
+```
+
+**Multiple groups on the same card** compose: each transform receives the output of the previous one (in priority order).
+
+---
+
 ## Assembling a GameSession
 
 ```csharp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.3] - 2026-05-18
+
+### Added
+- `AtomGroup<TDef>` — build-time cross-cutting transformation for atom definitions; selects by matcher predicate and applies a transform during `Build()`, in ascending priority order
+- `GameDefinitionBuilder.RegisterCardGroup` / `RegisterZoneGroup` / `RegisterPlayerGroup` — register named groups that patch card, zone, or player definitions before the `GameDefinition` is finalised; groups are purely build-time and leave no trace in the serialised output
+
 ## [0.6.2] - 2026-05-17
 
 ### Added

--- a/src/Archetype.Build/GameDefinitionBuilder.cs
+++ b/src/Archetype.Build/GameDefinitionBuilder.cs
@@ -41,6 +41,9 @@ public sealed class GameDefinitionBuilder
     private InitManifest? _initManifest;
     private IReadOnlyList<string>? _playableZoneNames;
     private IReadOnlyList<StateFieldDecl>? _sessionStateMap;
+    private readonly List<AtomGroup<CardDefinition>> _cardGroups = new();
+    private readonly List<AtomGroup<ZoneDefinition>> _zoneGroups = new();
+    private readonly List<AtomGroup<PlayerDefinition>> _playerGroups = new();
 
     // -----------------------------------------------------------------------
     //  Game identity
@@ -200,6 +203,54 @@ public sealed class GameDefinitionBuilder
     }
 
     // -----------------------------------------------------------------------
+    //  Atom groups
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Registers a build-time group that selects card definitions by
+    /// <paramref name="matcher"/> and transforms them via <paramref name="transform"/>.
+    /// Groups are applied in ascending <paramref name="priority"/> order during
+    /// <see cref="Build"/>, after all cards have been registered.
+    /// </summary>
+    public GameDefinitionBuilder RegisterCardGroup(
+        string name,
+        Func<CardDefinition, bool> matcher,
+        Func<CardDefinition, CardDefinition> transform,
+        int priority = 0)
+    {
+        _cardGroups.Add(new AtomGroup<CardDefinition>(name, matcher, transform, priority));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a build-time group that selects zone definitions by
+    /// <paramref name="matcher"/> and transforms them via <paramref name="transform"/>.
+    /// </summary>
+    public GameDefinitionBuilder RegisterZoneGroup(
+        string name,
+        Func<ZoneDefinition, bool> matcher,
+        Func<ZoneDefinition, ZoneDefinition> transform,
+        int priority = 0)
+    {
+        _zoneGroups.Add(new AtomGroup<ZoneDefinition>(name, matcher, transform, priority));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a build-time group that selects player definitions by
+    /// <paramref name="matcher"/> and transforms them via <paramref name="transform"/>.
+    /// </summary>
+    public GameDefinitionBuilder RegisterPlayerGroup(
+        string name,
+        Func<PlayerDefinition, bool> matcher,
+        Func<PlayerDefinition, PlayerDefinition> transform,
+        int priority = 0)
+    {
+        _playerGroups.Add(new AtomGroup<PlayerDefinition>(name, matcher, transform, priority));
+        return this;
+    }
+
+    // -----------------------------------------------------------------------
     //  Build
     // -----------------------------------------------------------------------
 
@@ -248,15 +299,19 @@ public sealed class GameDefinitionBuilder
             }
         }
 
+        var cardDefs   = ApplyGroups(_cardDefinitions,   _cardGroups);
+        var zoneDefs   = ApplyGroups(_zoneDefinitions,   _zoneGroups);
+        var playerDefs = ApplyGroups(_playerDefinitions, _playerGroups);
+
         var definition = new GameDefinition(
             Keywords:                    allKeywords,
-            CardDefinitions:             _cardDefinitions,
-            ZoneDefinitions:             _zoneDefinitions,
+            CardDefinitions:             cardDefs,
+            ZoneDefinitions:             zoneDefs,
             StateBasedRules:             _stateBasedRules,
             Phases:                      _phases,
             ActionRules:                 _actionRules,
             TriggerResolutionOrder:      _triggerResolutionOrder,
-            PlayerDefinitions:           _playerDefinitions,
+            PlayerDefinitions:           playerDefs,
             InitManifest:                _initManifest,
             PlayableZoneNames:           _playableZoneNames,
             Id:                          _id,
@@ -266,6 +321,29 @@ public sealed class GameDefinitionBuilder
         StateMapValidator.Validate(definition);
 
         return definition;
+    }
+
+    // -----------------------------------------------------------------------
+    //  Group application
+    // -----------------------------------------------------------------------
+
+    private static Dictionary<string, TDef> ApplyGroups<TDef>(
+        Dictionary<string, TDef> source,
+        List<AtomGroup<TDef>> groups)
+    {
+        if (groups.Count == 0)
+            return source;
+
+        var result = new Dictionary<string, TDef>(source);
+        foreach (var group in groups.OrderBy(g => g.Priority))
+        {
+            foreach (var key in result.Keys.ToList())
+            {
+                if (group.Matcher(result[key]))
+                    result[key] = group.Transform(result[key]);
+            }
+        }
+        return result;
     }
 
     // -----------------------------------------------------------------------
@@ -301,3 +379,13 @@ public sealed class GameDefinitionBuilder
         }
     }
 }
+
+/// <summary>
+/// A named, build-time transformation applied to all atom definitions
+/// that satisfy <see cref="Matcher"/>, in ascending <see cref="Priority"/> order.
+/// </summary>
+public sealed record AtomGroup<TDef>(
+    string Name,
+    Func<TDef, bool> Matcher,
+    Func<TDef, TDef> Transform,
+    int Priority);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,6 @@
     <PackageProjectUrl>https://github.com/bjornarprytz/Archetype</PackageProjectUrl>
     <PackageTags>archetype;card-game;game-engine;godot</PackageTags>
     <IsPackable>true</IsPackable>
-    <Version>0.6.2</Version>
+    <Version>0.6.3</Version>
   </PropertyGroup>
 </Project>

--- a/tests/Archetype.Tests/Builder/AtomGroupTests.cs
+++ b/tests/Archetype.Tests/Builder/AtomGroupTests.cs
@@ -1,0 +1,188 @@
+using Archetype.Build;
+using Archetype.Build.Extensions;
+using Archetype.Core;
+
+namespace Archetype.Tests.Builder;
+
+public class AtomGroupTests
+{
+    private static readonly CostDef DefaultCost = new(
+        Body: new EffectBlockDef([new EffectBlockStep("pay-mana", [])]),
+        Parameters: [],
+        TextTemplate: "Pay 1 mana");
+
+    private static GameDefinitionBuilder MinimalBuilder() =>
+        new GameDefinitionBuilder()
+            .WithId("test-game")
+            .WithInitManifest(InitManifest.Empty);
+
+    // -----------------------------------------------------------------------
+    //  Card groups
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RegisterCardGroup_AppliesTransformToMatchingCards()
+    {
+        var def = MinimalBuilder()
+            .AddCard("free", cb => cb.WithPrimaryEffect(b => b.Step("noop")))
+            .AddCard("costly", cb => cb
+                .WithPrimaryEffect(b => b.Step("noop"))
+                .AddCost(DefaultCost))
+            .RegisterCardGroup(
+                "default-cost",
+                matcher:   card => card.Cost is null or { Count: 0 },
+                transform: card => card with { Cost = [DefaultCost] })
+            .Build();
+
+        // "free" had no cost — group should have applied
+        Assert.NotNull(def.CardDefinitions["free"].Cost);
+        Assert.Single(def.CardDefinitions["free"].Cost!);
+
+        // "costly" already had a cost — matcher excluded it, still one cost
+        Assert.Single(def.CardDefinitions["costly"].Cost!);
+    }
+
+    [Fact]
+    public void RegisterCardGroup_NonMatchingCards_AreUnaffected()
+    {
+        var def = MinimalBuilder()
+            .AddCard(new CardDefinitionBuilder("creature")
+                .WithStaticProperty("type", "creature")
+                .WithPrimaryEffect(b => b.Step("noop"))
+                .Build())
+            .AddCard(new CardDefinitionBuilder("spell")
+                .WithStaticProperty("type", "spell")
+                .WithPrimaryEffect(b => b.Step("noop"))
+                .Build())
+            .RegisterCardGroup(
+                "spell-tag",
+                matcher:   card => card.StaticProperties.TryGetValue("type", out var t) && t is "spell",
+                transform: card => card with
+                {
+                    StaticProperties = new Dictionary<string, object>(card.StaticProperties) { ["tagged"] = true }
+                })
+            .Build();
+
+        Assert.False(def.CardDefinitions["creature"].StaticProperties.ContainsKey("tagged"));
+        Assert.True(def.CardDefinitions["spell"].StaticProperties.TryGetValue("tagged", out var v) && v is true);
+    }
+
+    [Fact]
+    public void RegisterCardGroup_PriorityOrder_LowerPriorityRunsFirst()
+    {
+        // priority=0 sets "counter" to 1.0, priority=1 doubles it to 2.0
+        var def = MinimalBuilder()
+            .AddCard("test", cb => cb.WithPrimaryEffect(b => b.Step("noop")))
+            .RegisterCardGroup(
+                "set-counter",
+                matcher:   _ => true,
+                transform: card => card with
+                {
+                    StaticProperties = new Dictionary<string, object>(card.StaticProperties) { ["counter"] = 1.0 }
+                },
+                priority: 0)
+            .RegisterCardGroup(
+                "double-counter",
+                matcher:   card => card.StaticProperties.ContainsKey("counter"),
+                transform: card => card with
+                {
+                    StaticProperties = new Dictionary<string, object>(card.StaticProperties)
+                    {
+                        ["counter"] = (double)card.StaticProperties["counter"] * 2
+                    }
+                },
+                priority: 1)
+            .Build();
+
+        Assert.Equal(2.0, def.CardDefinitions["test"].StaticProperties["counter"]);
+    }
+
+    [Fact]
+    public void RegisterCardGroup_HigherPriorityRegisteredFirst_StillRunsAfterLowerPriority()
+    {
+        // Register priority=1 first, priority=0 second — registration order should not affect application order
+        var def = MinimalBuilder()
+            .AddCard("test", cb => cb.WithPrimaryEffect(b => b.Step("noop")))
+            .RegisterCardGroup(
+                "double-counter",
+                matcher:   card => card.StaticProperties.ContainsKey("counter"),
+                transform: card => card with
+                {
+                    StaticProperties = new Dictionary<string, object>(card.StaticProperties)
+                    {
+                        ["counter"] = (double)card.StaticProperties["counter"] * 2
+                    }
+                },
+                priority: 1)
+            .RegisterCardGroup(
+                "set-counter",
+                matcher:   _ => true,
+                transform: card => card with
+                {
+                    StaticProperties = new Dictionary<string, object>(card.StaticProperties) { ["counter"] = 1.0 }
+                },
+                priority: 0)
+            .Build();
+
+        Assert.Equal(2.0, def.CardDefinitions["test"].StaticProperties["counter"]);
+    }
+
+    [Fact]
+    public void RegisterCardGroup_NoCards_DoesNotThrow()
+    {
+        var def = MinimalBuilder()
+            .RegisterCardGroup(
+                "default-cost",
+                matcher:   card => card.Cost is null or { Count: 0 },
+                transform: card => card with { Cost = [DefaultCost] })
+            .Build();
+
+        Assert.Empty(def.CardDefinitions);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Zone groups
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RegisterZoneGroup_AppliesTransformToMatchingZones()
+    {
+        var def = MinimalBuilder()
+            .AddZone("hand", new Dictionary<string, object>())
+            .AddZone("deck", new Dictionary<string, object> { ["hidden"] = true })
+            .RegisterZoneGroup(
+                "tag-visible",
+                matcher:   zone => !zone.StaticProperties.ContainsKey("hidden"),
+                transform: zone => zone with
+                {
+                    StaticProperties = new Dictionary<string, object>(zone.StaticProperties) { ["visible"] = true }
+                })
+            .Build();
+
+        Assert.True(def.ZoneDefinitions["hand"].StaticProperties.TryGetValue("visible", out var v) && v is true);
+        Assert.False(def.ZoneDefinitions["deck"].StaticProperties.ContainsKey("visible"));
+    }
+
+    // -----------------------------------------------------------------------
+    //  Player groups
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RegisterPlayerGroup_AppliesTransformToMatchingPlayers()
+    {
+        var def = MinimalBuilder()
+            .AddPlayer("hero",    new Dictionary<string, object> { ["role"] = "hero" })
+            .AddPlayer("villain", new Dictionary<string, object> { ["role"] = "villain" })
+            .RegisterPlayerGroup(
+                "hero-bonus",
+                matcher:   p => p.StaticProperties.TryGetValue("role", out var r) && r is "hero",
+                transform: p => p with
+                {
+                    StaticProperties = new Dictionary<string, object>(p.StaticProperties) { ["bonus"] = true }
+                })
+            .Build();
+
+        Assert.True(def.PlayerDefinitions["hero"].StaticProperties.TryGetValue("bonus", out var v) && v is true);
+        Assert.False(def.PlayerDefinitions["villain"].StaticProperties.ContainsKey("bonus"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `AtomGroup<TDef>` — a build-time mechanism that selects atom definitions by predicate and applies a transform during `Build()`, in ascending priority order
- Adds `RegisterCardGroup` / `RegisterZoneGroup` / `RegisterPlayerGroup` on `GameDefinitionBuilder`
- Groups are purely build-time; the serialised `GameDefinition` reflects post-application results with no group metadata
- Closes #24

## Design notes

The RFC proposed JSON serialisation of groups, but arbitrary transforms (e.g. attaching a `CostDef`) can't be meaningfully serialised. Since we're going C#-only (tooling server removal planned), groups are just `Func<TDef, bool>` matchers + `Func<TDef, TDef>` transforms — record `with` expressions make this idiomatic. "Don't override local" is the matcher's job, not the framework's.

## Test plan

- [x] Group applies to matching cards, skips non-matching
- [x] Priority ordering is respected regardless of registration order
- [x] Multiple groups compose (each transform receives the previous output)
- [x] Empty definition with a registered group does not throw
- [x] Zone and player groups work identically
- [x] Full suite: 275/275 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)